### PR TITLE
Build Config with Cordova Tab Width Default

### DIFF
--- a/node-tests/fixtures/config.xml/android-platform-node-expected.xml
+++ b/node-tests/fixtures/config.xml/android-platform-node-expected.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="emberCordovaExample" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  <name>emberCordovaExample</name>
-  <description>
-    A sample Apache Cordova application that responds to the deviceready event.
-  </description>
-  <author email="dev@cordova.apache.org" href="http://cordova.io">
-    Apache Cordova Team
-  </author>
-  <content src="index.html"/>
-  <plugin name="cordova-plugin-whitelist" spec="1"/>
-  <access origin="*"/>
-  <allow-intent href="http://*/*"/>
-  <allow-intent href="https://*/*"/>
-  <allow-intent href="tel:*"/>
-  <allow-intent href="sms:*"/>
-  <allow-intent href="mailto:*"/>
-  <allow-intent href="geo:*"/>
-  <allow-navigation href="*"/>
-  <platform name="android">
-    <icon src="res/icon/android/icon-60.png" height="72" width="72"/>
-  </platform>
-  <platform name="ios">
-    <icon src="res/icon/ios/icon.png" height="57" width="57"/>
-  </platform>
+    <name>emberCordovaExample</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html"/>
+    <plugin name="cordova-plugin-whitelist" spec="1"/>
+    <access origin="*"/>
+    <allow-intent href="http://*/*"/>
+    <allow-intent href="https://*/*"/>
+    <allow-intent href="tel:*"/>
+    <allow-intent href="sms:*"/>
+    <allow-intent href="mailto:*"/>
+    <allow-intent href="geo:*"/>
+    <allow-navigation href="*"/>
+    <platform name="android">
+        <icon src="res/icon/android/icon-60.png" height="72" width="72"/>
+    </platform>
+    <platform name="ios">
+        <icon src="res/icon/ios/icon.png" height="57" width="57"/>
+    </platform>
 </widget>

--- a/node-tests/fixtures/config.xml/android-platform-node.xml
+++ b/node-tests/fixtures/config.xml/android-platform-node.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="emberCordovaExample" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  <name>emberCordovaExample</name>
-  <description>
-    A sample Apache Cordova application that responds to the deviceready event.
-  </description>
-  <author email="dev@cordova.apache.org" href="http://cordova.io">
-    Apache Cordova Team
-  </author>
-  <content src="index.html"/>
-  <plugin name="cordova-plugin-whitelist" spec="1"/>
-  <access origin="*"/>
-  <allow-intent href="http://*/*"/>
-  <allow-intent href="https://*/*"/>
-  <allow-intent href="tel:*"/>
-  <allow-intent href="sms:*"/>
-  <allow-intent href="mailto:*"/>
-  <allow-intent href="geo:*"/>
-  <allow-navigation href="*"/>
-  <platform name="android">
-    <icon src="res/icon/android/icon-60.png" height="72" width="72"/>
-  </platform>
+    <name>emberCordovaExample</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html"/>
+    <plugin name="cordova-plugin-whitelist" spec="1"/>
+    <access origin="*"/>
+    <allow-intent href="http://*/*"/>
+    <allow-intent href="https://*/*"/>
+    <allow-intent href="tel:*"/>
+    <allow-intent href="sms:*"/>
+    <allow-intent href="mailto:*"/>
+    <allow-intent href="geo:*"/>
+    <allow-navigation href="*"/>
+    <platform name="android">
+        <icon src="res/icon/android/icon-60.png" height="72" width="72"/>
+    </platform>
 </widget>

--- a/node-tests/fixtures/config.xml/ios-platform-node.xml
+++ b/node-tests/fixtures/config.xml/ios-platform-node.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="emberCordovaExample" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  <name>emberCordovaExample</name>
-  <description>
-    A sample Apache Cordova application that responds to the deviceready event.
-  </description>
-  <author email="dev@cordova.apache.org" href="http://cordova.io">
-    Apache Cordova Team
-  </author>
-  <content src="index.html"/>
-  <plugin name="cordova-plugin-whitelist" spec="1"/>
-  <access origin="*"/>
-  <allow-intent href="http://*/*"/>
-  <allow-intent href="https://*/*"/>
-  <allow-intent href="tel:*"/>
-  <allow-intent href="sms:*"/>
-  <allow-intent href="mailto:*"/>
-  <allow-intent href="geo:*"/>
-  <allow-navigation href="*"/>
-  <platform name="ios">
-  </platform>
+    <name>emberCordovaExample</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html"/>
+    <plugin name="cordova-plugin-whitelist" spec="1"/>
+    <access origin="*"/>
+    <allow-intent href="http://*/*"/>
+    <allow-intent href="https://*/*"/>
+    <allow-intent href="tel:*"/>
+    <allow-intent href="sms:*"/>
+    <allow-intent href="mailto:*"/>
+    <allow-intent href="geo:*"/>
+    <allow-navigation href="*"/>
+    <platform name="ios">
+    </platform>
 </widget>

--- a/node-tests/fixtures/config.xml/no-and-ios-platform-node-expected.xml
+++ b/node-tests/fixtures/config.xml/no-and-ios-platform-node-expected.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <widget id="emberCordovaExample" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  <name>emberCordovaExample</name>
-  <description>
-    A sample Apache Cordova application that responds to the deviceready event.
-  </description>
-  <author email="dev@cordova.apache.org" href="http://cordova.io">
-    Apache Cordova Team
-  </author>
-  <content src="index.html"/>
-  <plugin name="cordova-plugin-whitelist" spec="1"/>
-  <access origin="*"/>
-  <allow-intent href="http://*/*"/>
-  <allow-intent href="https://*/*"/>
-  <allow-intent href="tel:*"/>
-  <allow-intent href="sms:*"/>
-  <allow-intent href="mailto:*"/>
-  <allow-intent href="geo:*"/>
-  <allow-navigation href="*"/>
-  <platform name="ios">
-    <icon src="res/icon/ios/icon.png" height="57" width="57"/>
-  </platform>
+    <name>emberCordovaExample</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html"/>
+    <plugin name="cordova-plugin-whitelist" spec="1"/>
+    <access origin="*"/>
+    <allow-intent href="http://*/*"/>
+    <allow-intent href="https://*/*"/>
+    <allow-intent href="tel:*"/>
+    <allow-intent href="sms:*"/>
+    <allow-intent href="mailto:*"/>
+    <allow-intent href="geo:*"/>
+    <allow-navigation href="*"/>
+    <platform name="ios">
+        <icon src="res/icon/ios/icon.png" height="57" width="57"/>
+    </platform>
 </widget>

--- a/node-tests/fixtures/config.xml/no-platform-nodes.xml
+++ b/node-tests/fixtures/config.xml/no-platform-nodes.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <widget id="emberCordovaExample" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
-  <name>emberCordovaExample</name>
-  <description>
-    A sample Apache Cordova application that responds to the deviceready event.
-  </description>
-  <author email="dev@cordova.apache.org" href="http://cordova.io">
-    Apache Cordova Team
-  </author>
-  <content src="index.html"/>
-  <plugin name="cordova-plugin-whitelist" spec="1"/>
-  <access origin="*"/>
-  <allow-intent href="http://*/*"/>
-  <allow-intent href="https://*/*"/>
-  <allow-intent href="tel:*"/>
-  <allow-intent href="sms:*"/>
-  <allow-intent href="mailto:*"/>
-  <allow-intent href="geo:*"/>
-  <allow-navigation href="*"/>
+    <name>emberCordovaExample</name>
+    <description>
+        A sample Apache Cordova application that responds to the deviceready event.
+    </description>
+    <author email="dev@cordova.apache.org" href="http://cordova.io">
+        Apache Cordova Team
+    </author>
+    <content src="index.html"/>
+    <plugin name="cordova-plugin-whitelist" spec="1"/>
+    <access origin="*"/>
+    <allow-intent href="http://*/*"/>
+    <allow-intent href="https://*/*"/>
+    <allow-intent href="tel:*"/>
+    <allow-intent href="sms:*"/>
+    <allow-intent href="mailto:*"/>
+    <allow-intent href="geo:*"/>
+    <allow-navigation href="*"/>
 </widget>

--- a/src/utils/update-config.js
+++ b/src/utils/update-config.js
@@ -29,7 +29,13 @@ const parseXML = function(xmlPath) {
 };
 
 const saveXML = function(json, xmlPath) {
-  const builder = new xml2js.Builder();
+  const builder = new xml2js.Builder({
+    renderOpts: {
+      'pretty': true,
+      'indent': '    ',
+      'newline': '\n'
+    }
+  });
   const xml = builder.buildObject(json);
 
   // Add missing trailing newline


### PR DESCRIPTION
As reported by [kitsunde](https://github.com/isleofcode/ember-cordova/issues/158#issue-179640073), splicon currently builds `config.xml` with 2-space wide tabs rather than the Cordova default of 4-space wide tabs.

Cordova's default of 4-space wide tabs should be respected.