### PR TITLE
Add icon size 120 and 152 icons for ios

### DIFF
--- a/src/platform-icon-sizes.js
+++ b/src/platform-icon-sizes.js
@@ -20,7 +20,11 @@ module.exports = {
       { size: 144, id: 'icon-72@2x' },
       { size: 50,  id: 'icon-50' },
       { size: 100, id: 'icon-50@2x' },
-      { size: 167, id: 'icon-83.5@2x' }
+      { size: 167, id: 'icon-83.5@2x' },
+      { size: 120, id: 'icon-120' },
+      { size: 240, id: 'icon-120@2x' },
+      { size: 152, id: 'icon-152' },
+      { size: 304, id: 'icon-152@2x' }
     ]
   },
 


### PR DESCRIPTION
Adds icons for size 120 and 152: https://developer.apple.com/ios/human-interface-guidelines/icons-and-images/app-icon/

Solves: #17