### PR TITLE
Add new icon/splash sizes for Xcode 9

### DIFF
--- a/src/platform-icon-sizes.js
+++ b/src/platform-icon-sizes.js
@@ -24,7 +24,14 @@ module.exports = {
       { size: 120, id: 'icon-120' },
       { size: 240, id: 'icon-120@2x' },
       { size: 152, id: 'icon-152' },
-      { size: 304, id: 'icon-152@2x' }
+      { size: 304, id: 'icon-152@2x' },
+      { size: 20, id: 'icon-20' },
+      { size: 48, id: 'icon-24@2x' },
+      { size: 55, id: 'icon-27.5@2x' },
+      { size: 88, id: 'icon-44@2x' },
+      { size: 172, id: 'icon-86@2x' },
+      { size: 196, id: 'icon-98@2x' },
+      { size: 1024, id: 'icon-1024' }
     ]
   },
 

--- a/src/platform-splash-sizes.js
+++ b/src/platform-splash-sizes.js
@@ -22,7 +22,10 @@ module.exports = {
       { width: 2048, height: 1536, id: '2048-1536' },
 
       { width: 2048, height: 2732, id: '2048-2732' },
-      { width: 2732, height: 2048, id: '2732-2048' }
+      { width: 2732, height: 2048, id: '2732-2048' },
+
+      { width: 1125, height: 2436, id: '1125-2436' },
+      { width: 2436, height: 1125, id: '2436-1125' }
     ]
   },
 


### PR DESCRIPTION
Xcode 9 gives me a bunch of warnings about missing assets, so this adds all the sizes it wanted.

Most importantly adds 1024 as people are getting rejected because of it (see #19).

Also importantly adds iPhone X launch images which removes the letterbox effect (who knows why).